### PR TITLE
Add argilla deployment files and 101 notebook

### DIFF
--- a/credentials_example.env
+++ b/credentials_example.env
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=XXX
 LLM_API_URL="https://text-generation-api-llm.example.com/api/v1/generate"
+ARGILLA_API_KEY=XXX
+ARGILLA_API_URL=XXX

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -20,3 +20,7 @@ The readme contains description of experiment notebooks in this repository.
 
 ## Model Serving
 * [Model Serving with Ray](./model_serving/ray-serve-llm.ipynb) provides a demo for how to serve an LLM on OpenShift using a multi-GPU ray cluster. 
+
+## Feedback
+
+* [Argilla 101](./feedback/argilla_101.ipynb) shows how to connect with and use the Argilla instance on the cluster.

--- a/notebooks/feedback/argilla_101.ipynb
+++ b/notebooks/feedback/argilla_101.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3c61c1c1-e146-4b49-9d9c-cf85cd36e452",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# [Argilla 101](https://docs.argilla.io/en/latest/index.html)\n",
+    "This notebook shows how to connect with the Argilla instance on the ET cluster. To run this notebook, you will need to provide the api key as the `ARGILLA_API_KEY` and the API URL as `ARGILLA_API_URL`  environment variables. You can place the key in a `credentials.env` at the root of this repository and this notebook will load it in the following cell. For an example, look at the `credentials_example.env` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b7112eb1-2adf-4802-a035-bac21d469469",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import argilla as rg\n",
+    "from dotenv import load_dotenv, find_dotenv\n",
+    "import os\n",
+    "# Load environment variables\n",
+    "load_dotenv(find_dotenv(\"credentials.env\"), override=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ad714adb-aaba-4aec-abad-0f44e555c459",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/app-root/lib64/python3.8/site-packages/argilla/client/client.py:124: UserWarning: Default user was detected and no workspace configuration was provided, so the default 'argilla' workspace will be used. If you want to setup another workspace, use the `rg.set_workspace` function or provide a different one on `rg.init`\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Setup connection with the Argilla instance\n",
+    "rg.init(api_url=os.getenv(\"ARGILLA_API_URL\"),\n",
+    "        api_key=os.getenv(\"ARGILLA_API_KEY\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6632db85-72bd-4c69-a071-14712d0bc127",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an example feedback dataset\n",
+    "\n",
+    "dataset = rg.FeedbackDataset(\n",
+    "    guidelines=\"Add some guidelines for the annotation team here.\",\n",
+    "    fields=[\n",
+    "        rg.TextField(name=\"prompt\", title=\"Human prompt\"),\n",
+    "        rg.TextField(name=\"output\", title=\"Generated output\", use_markdown=True)\n",
+    "    ],\n",
+    "    questions =[\n",
+    "        rg.RatingQuestion(\n",
+    "            name=\"rating\",\n",
+    "            title=\"Rate the quality of the response:\",\n",
+    "            description=\"1 = very bad - 5= very good\",\n",
+    "            required=True,\n",
+    "            values=[1,2,3,4,5]\n",
+    "        ),\n",
+    "        rg.TextQuestion(\n",
+    "            name=\"corrected-text\",\n",
+    "            title=\"Provide a correction to the response:\",\n",
+    "            required=False,\n",
+    "            use_markdown=True\n",
+    "        )\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4f2b7492-176b-4a65-a32d-d51e9bd1d835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an example record \n",
+    "record = rg.FeedbackRecord(\n",
+    "    fields={\n",
+    "        \"prompt\": \"Why can camels survive long without water?\",\n",
+    "        \"output\": \"Camels use the fat in their humps to keep them filled with energy and hydration for long periods of time.\"\n",
+    "    }\n",
+    ")\n",
+    "# Add it to our feedback dataset\n",
+    "dataset.add_records(record)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "71e7fecf-b98e-471e-8e37-f98bdc6996ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Pushing records to Argilla...: 100%|██████████| 1/1 [00:00<00:00, 41.51it/s]\n",
+      "/opt/app-root/lib64/python3.8/site-packages/argilla/client/feedback/dataset/mixins.py:195: DeprecationWarning: Calling `push_to_argilla` no longer implies that the `FeedbackDataset` can be updated in Argilla. If you want to push a `FeedbackDataset` and then update it in Argilla, you need to catch the returned object and use it instead: `remote_ds = ds.push_to_argilla(...)`. Otherwise, you can just call `push_to_argilla` and then `from_argilla` to retrieve the `FeedbackDataset` from Argilla, so the current `FeedbackDataset` can be retrieved as `FeedbackDataset.from_argilla(id='41f742ab-54dc-4e34-b25f-89de6acae78e')`.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This publishes the dataset with its records to the Argilla instance for feedback annotation\n",
+    "remote_dataset = dataset.push_to_argilla(name=\"argilla-101\", workspace=\"argilla\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c39e0553-9260-4737-b5d9-73119b16d295",
+   "metadata": {},
+   "source": [
+    "< Go to Argilla UI and annotate >"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9fb1d77e-d7ae-4b53-9e3b-87273c2fe15d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve the annotated feedback dataset\n",
+    "\n",
+    "feedback = rg.FeedbackDataset.from_argilla(\n",
+    "    name=\"argilla-101\",\n",
+    "    workspace=\"argilla\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fd1d8820-f8b0-4448-bfbb-dbab54a981d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<FeedbackDataset id=41f742ab-54dc-4e34-b25f-89de6acae78e name=argilla-101 workspace=Workspace(id=e30eb6f7-6461-43a7-916d-e69c36807bea, name=argilla, inserted_at=2023-08-24 22:53:29.608650, updated_at=2023-08-24 22:53:29.608650) url=http://argilla-test-route-argilla-test.apps.et-cluster.6mwp.p1.openshiftapps.com/dataset/41f742ab-54dc-4e34-b25f-89de6acae78e/annotation-mode fields=[TextField(id=UUID('7d1989c5-3bb6-4d99-b211-cf01e27e5b03'), name='prompt', title='Human prompt', required=True, type='text', settings={'type': 'text', 'use_markdown': False}, use_markdown=False), TextField(id=UUID('ec5f967f-a6c9-4899-abab-41845eafcc1e'), name='output', title='Generated output', required=True, type='text', settings={'type': 'text', 'use_markdown': True}, use_markdown=True)] questions=[RatingQuestion(id=UUID('1b71bb30-2658-462e-acda-d138d7174d38'), name='rating', title='Rate the quality of the response:', description='1 = very bad - 5= very good', required=True, type='rating', settings={'type': 'rating', 'options': [{'value': 1}, {'value': 2}, {'value': 3}, {'value': 4}, {'value': 5}]}, values=[1, 2, 3, 4, 5]), TextQuestion(id=UUID('e0c41d77-6a3d-4620-b7a3-af381e1c5ceb'), name='corrected-text', title='Provide a correction to the response:', description=None, required=False, type='text', settings={'type': 'text', 'use_markdown': True}, use_markdown=True)] guidelines=Add some guidelines for the annotation team here.>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "feedback"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "28b84c79-6674-4492-a6f0-a88161b69737",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The feedback rating (1-5) is 2 and the corrected text is:'Camels use the fat in their humps to keep them filled with energy and hydration for long periods of time. They can drink 50 gallons of water in one go. '\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Extract example annotation\n",
+    "example_annotation = feedback.records[0].responses[0].values\n",
+    "\n",
+    "rating = example_annotation['rating'].value\n",
+    "corrected_text = example_annotation['corrected-text'].value\n",
+    "\n",
+    "print(f\"The feedback rating (1-5) is {rating} and the corrected text is:'{corrected_text}'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43370e2e-cf60-4fc6-901b-cd8cb6732e08",
+   "metadata": {},
+   "source": [
+    "#### Next, we are going to use this notebook to create feedback collection for the ROSA docs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/feedback/argilla_deployment_files/argilla-server-deployment.yaml
+++ b/notebooks/feedback/argilla_deployment_files/argilla-server-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argilla-server-deployment
+  labels:
+    app: argilla-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: argilla-server
+  template:
+    metadata:
+      labels:
+        app: argilla-server
+    spec:
+      initContainers:
+        - name: wait-for-elasticsearch
+          image: alpine/curl:latest
+          command: [ "sh", "-c",
+            "ELASTICSEARCH_URL='http://elasticsearch:9200'; status_code=$(curl -s -o /dev/null -w '%{http_code}' $ELASTICSEARCH_URL); while [ $status_code -ne 200 ]; do sleep 5; status_code=$(curl -s -o /dev/null -w '%{http_code}' $ELASTICSEARCH_URL); echo Sleeping...; done; echo Elasticsearch Connected " ]
+      containers:
+        - name: argilla-server
+          image: argilla/argilla-server:latest
+          env:
+            - name: ARGILLA_ELASTICSEARCH
+              value: "http://elasticsearch:9200"
+            - name: ARGILLA_DATABASE_URL
+              value: "postgresql://user:password@IP:port/databasename"          
+          ports:
+            - containerPort: 6900
+          resources:
+            requests:
+              cpu: "0.5"
+            limits:
+              cpu: "1"

--- a/notebooks/feedback/argilla_deployment_files/argilla-server-hpa.yaml
+++ b/notebooks/feedback/argilla_deployment_files/argilla-server-hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: argilla-server-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argilla-server-deployment
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/notebooks/feedback/argilla_deployment_files/argilla-server-ingress.yaml
+++ b/notebooks/feedback/argilla_deployment_files/argilla-server-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argilla-server-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argilla-server
+                port:
+                  number: 6900

--- a/notebooks/feedback/argilla_deployment_files/argilla-server-service.yaml
+++ b/notebooks/feedback/argilla_deployment_files/argilla-server-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argilla-server
+  labels:
+    app: argilla-server
+spec:
+  selector:
+    app: argilla-server
+  ports:
+  - name: http
+    port: 6900

--- a/notebooks/feedback/argilla_deployment_files/elasticsearch-deployment.yaml
+++ b/notebooks/feedback/argilla_deployment_files/elasticsearch-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+  labels:
+    app: elasticsearch
+spec:
+  selector:
+    matchLabels:
+      app: elasticsearch
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
+          resources:
+            requests:
+              cpu: 0.25
+              memory: 1Gi
+            limits:
+              cpu: 1
+              memory: 2Gi
+          ports:
+            - containerPort: 9200
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: ES_JAVA_OPTS
+              value: -Xms256m -Xmx256m
+            - name: cluster.routing.allocation.disk.threshold_enabled
+              value: "false"
+            - name: xpack.security.enabled
+              value: "false"
+          volumeMounts:
+            - mountPath: /usr/share/elasticsearch/data
+              name: elasticsearch-data
+      volumes:
+        - name: elasticsearch-data
+          persistentVolumeClaim:
+            claimName: elasticsearch-pvc

--- a/notebooks/feedback/argilla_deployment_files/elasticsearch-pvc.yaml
+++ b/notebooks/feedback/argilla_deployment_files/elasticsearch-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/notebooks/feedback/argilla_deployment_files/elasticsearch-service.yaml
+++ b/notebooks/feedback/argilla_deployment_files/elasticsearch-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  labels:
+    app: elasticsearch
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+  - name: http
+    port: 9200


### PR DESCRIPTION
This PR adds deployment files for Argilla and 101 notebook on how to use it. 

The upstream deployment files can be found [here](https://github.com/argilla-io/argilla/tree/develop/k8s). 

This PR changes the deployment server yaml by adding a PostgreSQLdatabase instead of SQLite (default db that Argilla comes with) as SQLite gave permission errors. The PostgresSQL database was deployed using the default OpenShift database service. Also, we added a route to access the service.



