### PR TITLE
Add support for hosted llama model

### DIFF
--- a/backend-app/answer_generation.py
+++ b/backend-app/answer_generation.py
@@ -1,54 +1,20 @@
 from langchain.chains.question_answering import load_qa_chain
 from langchain.llms import OpenAI
+from custom_llm import CustomLLM
+import os
 from dotenv import load_dotenv, find_dotenv
 from langchain.prompts.prompt import PromptTemplate
-
-PROMPT_TEMPLATE = """
-As an engineer generating answers for questions around the
-Red Hat Openshift Service on AWS (ROSA) product, the goal is
-to generate answers from the given context. Do not make up answers and stick to the context. 
-If you don't know the answer, please respond with: "I don't know"
-
-Here are a few input, context, and output pairs examples to guide the model:
-
-Question: "What is Red Hat OpenShift Service on AWS (ROSA)?"
-Context: # Getting support for Red Hat OpenShift Service on AWS
-
-Get support for Red Hat OpenShift Service on AWS (ROSA).
-
-# Red Hat OpenShift Service on AWS - FAQ
-
-## General
-
-### What is Red Hat OpenShift Service on AWS (ROSA)?
-Red Hat Openshift Service on AWS (ROSA) is a fully-managed turnkey application platform that allows
-you to focus on what matters most, delivering value to your customers by building and deploying applications.
-Red Hat SRE experts manage the underlying platform so you don’t have to worry about the complexity of infrastructure management.
-
-### Where can I go to get more information/details?
-- [ROSA Webpage](https://www.openshift.com/products/amazon-openshift)
-- [ROSA Workshop](https://www.rosaworkshop.io)
-- [ROSA Documentation](https://docs.openshift.com/rosa/welcome/index.html)
-
-Additional key features of Red Hat OpenShift Service on AWS:
-
-You can quickly create a Red Hat OpenShift Service on AWS (ROSA) cluster with the AWS Security Token Service (STS) by using the default installation options. The following summary describes the default cluster specifications.
-Answer: "Red Hat Openshift Service on AWS (ROSA) is a fully-managed turnkey application platform that allows
-you to focus on what matters most, delivering value to your customers by building and deploying applications.
-Red Hat SRE experts manage the underlying platform so you don’t have to worry about the complexity of infrastructure management."
-
-
-Question: {question}
-Context: {context}
-Answer:
-"""
+from custom_prompt import PROMPT_TEMPLATE_LLAMA, PROMPT_TEMPLATE_OPENAI
 
 class AnswerGeneration:
     def __init__(self, vector_store, model_name):
-        load_dotenv(find_dotenv("credentials.env"),
-            override=True)
         self.vector_store = vector_store
-        self.model = OpenAI(model=model_name, temperature=0)
+        if model_name=="text-davinci-003":
+            self.model = OpenAI(model=model_name, temperature=0)
+            self.prompt = PROMPT_TEMPLATE_OPENAI
+        elif model_name=="llama2":
+            self.model = CustomLLM(api_url=os.getenv("LLAMA_LLM_URL"))
+            self.prompt = PROMPT_TEMPLATE_LLAMA
 
     
     def _get_prompt(self, prompt_template):
@@ -60,10 +26,9 @@ class AnswerGeneration:
     def generate(self,
                  query,
                  candidate_docs,
-                 prompt_template,
                  chain_type="stuff"):
         
-        prompt = self._get_prompt(prompt_template)
+        prompt = self._get_prompt(self.prompt)
         chain = load_qa_chain(self.model,
                               chain_type=chain_type,
                               prompt=prompt)
@@ -72,4 +37,5 @@ class AnswerGeneration:
                         "question": query},
                        return_only_outputs=True)
         
+
         return answer['output_text']

--- a/backend-app/app.py
+++ b/backend-app/app.py
@@ -1,7 +1,8 @@
 from document_retrieval import DocumentRetrieval
-from answer_generation import PROMPT_TEMPLATE, AnswerGeneration
+from answer_generation import PROMPT_TEMPLATE_OPENAI, PROMPT_TEMPLATE_LLAMA, AnswerGeneration
 from feedback import FeedbackCollection
 import gradio as gr
+
 
 if __name__ == "__main__":
     def answer(query):
@@ -17,10 +18,9 @@ if __name__ == "__main__":
 
             # Get answers
             generation = AnswerGeneration(retrieval.vector_store,
-                                          'text-davinci-003')
-            answer = generation.generate(query,
-                                top_candidates,
-                                PROMPT_TEMPLATE)
+                                          'llama2')
+            # If you want to change the model prompt, it is in prompt.py file
+            answer = generation.generate(query, top_candidates)
             answer = answer.strip("\"")
             
             # Add to feedback

--- a/backend-app/app.py
+++ b/backend-app/app.py
@@ -1,5 +1,5 @@
 from document_retrieval import DocumentRetrieval
-from answer_generation import PROMPT_TEMPLATE_OPENAI, PROMPT_TEMPLATE_LLAMA, AnswerGeneration
+from answer_generation import AnswerGeneration
 from feedback import FeedbackCollection
 import gradio as gr
 

--- a/backend-app/custom_llm.py
+++ b/backend-app/custom_llm.py
@@ -1,0 +1,39 @@
+import requests 
+from typing import Optional, List, Mapping, Any
+from langchain.llms.base import LLM
+from langchain.callbacks.manager import CallbackManagerForLLMRun
+
+# Sources:
+# https://python.langchain.com/docs/modules/model_io/models/llms/custom_llm
+# https://github.com/redhat-et/foundation-models-for-documentation/blob/master/notebooks/langchain-api-client.ipynb
+# https://github.com/HunterGerlach/deep-thought/blob/main/src/hosted_llm.py
+
+class CustomLLM(LLM):
+    api_url: str
+    "The URL of the API endpoint."
+
+    @property
+    def _llm_type(self) -> str:
+        return "custom"
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        if stop is not None:
+            raise ValueError("stop kwargs are not permitted.")
+        """Call the LLM."""
+        response = requests.get(self.api_url,
+                                params={"text" : prompt},
+                                timeout=600)
+        if response.status_code == 200:
+            return str(response.content).split("[/INST]")[1]
+        return f"Model Server is not Working due to error {response.status_code}"
+
+    @property
+    def _identifying_params(self) -> Mapping[str, Any]:
+        """Get the identifying parameters."""
+        return {"api_url": self.api_url}

--- a/backend-app/custom_prompt.py
+++ b/backend-app/custom_prompt.py
@@ -1,0 +1,52 @@
+PROMPT_TEMPLATE_OPENAI = """
+As an engineer generating answers for questions around the
+Red Hat Openshift Service on AWS (ROSA) product, use the Question and the Context to create the final Answer.
+Do not make up the Answer and stick to the Context. 
+If you don't know the answer, please respond with: "I don't know"
+
+Here is a guiding Question, Context, and Answer examples:
+
+Question: "What is Red Hat OpenShift Service on AWS (ROSA)?"
+Context: # Getting support for Red Hat OpenShift Service on AWS
+
+Get support for Red Hat OpenShift Service on AWS (ROSA).
+
+# Red Hat OpenShift Service on AWS - FAQ
+
+## General
+
+### What is Red Hat OpenShift Service on AWS (ROSA)?
+Red Hat Openshift Service on AWS (ROSA) is a fully-managed turnkey application platform that allows
+you to focus on what matters most, delivering value to your customers by building and deploying applications.
+Red Hat SRE experts manage the underlying platform so you don’t have to worry about the complexity of infrastructure management.
+
+### Where can I go to get more information/details?
+- [ROSA Webpage](https://www.openshift.com/products/amazon-openshift)
+- [ROSA Workshop](https://www.rosaworkshop.io)
+- [ROSA Documentation](https://docs.openshift.com/rosa/welcome/index.html)
+
+Additional key features of Red Hat OpenShift Service on AWS:
+
+You can quickly create a Red Hat OpenShift Service on AWS (ROSA) cluster with the AWS Security Token Service (STS) by using the default installation options. The following summary describes the default cluster specifications.
+
+Answer: "Red Hat Openshift Service on AWS (ROSA) is a fully-managed turnkey application platform that allows
+you to focus on what matters most, delivering value to your customers by building and deploying applications.
+Red Hat SRE experts manage the underlying platform so you don’t have to worry about the complexity of infrastructure management."
+
+
+Question: {question}
+Context: {context}
+Answer: """
+
+PROMPT_TEMPLATE_LLAMA = """
+            "<s>[INST] <<SYS>> \n"
+            "Below is the only information you know.\n"
+            "It was obtained by doing a vector search for the user's query:\n\n"
+            "---START INFO---\n\n{context}\n\n"
+            "---END INFO---\n\nYou must acknowledge the user's original query "
+            f"of \"{question}\". "
+            "Attempt to generate a summary of what you know from the sources provided "
+            "based ONLY on the information given and ONLY if it relates to the original query. "
+            "Use no other knowledge to respond. Do not make anything up. "
+            "<</SYS>>"
+            [/INST] """


### PR DESCRIPTION
The PR adds support for the hosted llama model as the choice of model for the answer generation feature of the application. 


The dev environment application that builds from my fork's backend branch can be accessed from the routes in `rosa-doc-search-dev` project on the OpenShift cluster.